### PR TITLE
feat(dashboard): add code owner migration trend charts

### DIFF
--- a/dashboard/public/metrics/timeline.json
+++ b/dashboard/public/metrics/timeline.json
@@ -1178,6 +1178,411 @@
         "Spinner"
       ]
     ],
+    "codeOwnerTimeline": {
+      "dates": [
+        "2026-02-27",
+        "2026-03-06",
+        "2026-03-13"
+      ],
+      "owners": {
+        "@MetaMask/accounts-engineers": {
+          "migrationPercentage": [
+            19.29,
+            20.54,
+            20.54
+          ],
+          "mmdsInstances": [
+            38,
+            38,
+            38
+          ],
+          "deprecatedInstances": [
+            159,
+            147,
+            147
+          ],
+          "totalInstances": [
+            197,
+            185,
+            185
+          ]
+        },
+        "@MetaMask/card": {
+          "migrationPercentage": [
+            63.64,
+            64.94,
+            68.36
+          ],
+          "mmdsInstances": [
+            266,
+            276,
+            296
+          ],
+          "deprecatedInstances": [
+            152,
+            149,
+            137
+          ],
+          "totalInstances": [
+            418,
+            425,
+            433
+          ]
+        },
+        "@MetaMask/confirmations": {
+          "migrationPercentage": [
+            18.44,
+            17.35,
+            17.41
+          ],
+          "mmdsInstances": [
+            71,
+            72,
+            74
+          ],
+          "deprecatedInstances": [
+            314,
+            343,
+            351
+          ],
+          "totalInstances": [
+            385,
+            415,
+            425
+          ]
+        },
+        "@MetaMask/core-platform": {
+          "migrationPercentage": [
+            0.99,
+            0.99,
+            0.99
+          ],
+          "mmdsInstances": [
+            1,
+            1,
+            1
+          ],
+          "deprecatedInstances": [
+            100,
+            100,
+            100
+          ],
+          "totalInstances": [
+            101,
+            101,
+            101
+          ]
+        },
+        "@MetaMask/metamask-assets": {
+          "migrationPercentage": [
+            38.58,
+            38.58,
+            40.37
+          ],
+          "mmdsInstances": [
+            103,
+            103,
+            109
+          ],
+          "deprecatedInstances": [
+            164,
+            164,
+            161
+          ],
+          "totalInstances": [
+            267,
+            267,
+            270
+          ]
+        },
+        "@MetaMask/metamask-earn": {
+          "migrationPercentage": [
+            3.37,
+            3.69,
+            6.23
+          ],
+          "mmdsInstances": [
+            10,
+            11,
+            19
+          ],
+          "deprecatedInstances": [
+            287,
+            287,
+            286
+          ],
+          "totalInstances": [
+            297,
+            298,
+            305
+          ]
+        },
+        "@MetaMask/mobile-core-ux": {
+          "migrationPercentage": [
+            10.29,
+            12.41,
+            12.41
+          ],
+          "mmdsInstances": [
+            35,
+            36,
+            36
+          ],
+          "deprecatedInstances": [
+            305,
+            254,
+            254
+          ],
+          "totalInstances": [
+            340,
+            290,
+            290
+          ]
+        },
+        "@MetaMask/mobile-platform": {
+          "migrationPercentage": [
+            75,
+            75,
+            75
+          ],
+          "mmdsInstances": [
+            3,
+            3,
+            3
+          ],
+          "deprecatedInstances": [
+            1,
+            1,
+            1
+          ],
+          "totalInstances": [
+            4,
+            4,
+            4
+          ]
+        },
+        "@MetaMask/notifications": {
+          "migrationPercentage": [
+            5.06,
+            5.13,
+            5.13
+          ],
+          "mmdsInstances": [
+            4,
+            4,
+            4
+          ],
+          "deprecatedInstances": [
+            75,
+            74,
+            74
+          ],
+          "totalInstances": [
+            79,
+            78,
+            78
+          ]
+        },
+        "@MetaMask/perps": {
+          "migrationPercentage": [
+            12.9,
+            12.93,
+            13.43
+          ],
+          "mmdsInstances": [
+            104,
+            105,
+            110
+          ],
+          "deprecatedInstances": [
+            702,
+            707,
+            709
+          ],
+          "totalInstances": [
+            806,
+            812,
+            819
+          ]
+        },
+        "@MetaMask/predict": {
+          "migrationPercentage": [
+            73.3,
+            73.3,
+            75.54
+          ],
+          "mmdsInstances": [
+            409,
+            409,
+            454
+          ],
+          "deprecatedInstances": [
+            149,
+            149,
+            147
+          ],
+          "totalInstances": [
+            558,
+            558,
+            601
+          ]
+        },
+        "@MetaMask/ramp": {
+          "migrationPercentage": [
+            9.41,
+            9.87,
+            10.57
+          ],
+          "mmdsInstances": [
+            72,
+            78,
+            84
+          ],
+          "deprecatedInstances": [
+            693,
+            712,
+            711
+          ],
+          "totalInstances": [
+            765,
+            790,
+            795
+          ]
+        },
+        "@MetaMask/rewards": {
+          "migrationPercentage": [
+            88.95,
+            88.05,
+            88.14
+          ],
+          "mmdsInstances": [
+            451,
+            457,
+            483
+          ],
+          "deprecatedInstances": [
+            56,
+            62,
+            65
+          ],
+          "totalInstances": [
+            507,
+            519,
+            548
+          ]
+        },
+        "@MetaMask/swaps-engineers": {
+          "migrationPercentage": [
+            18.67,
+            33.71,
+            40.31
+          ],
+          "mmdsInstances": [
+            28,
+            59,
+            77
+          ],
+          "deprecatedInstances": [
+            122,
+            116,
+            114
+          ],
+          "totalInstances": [
+            150,
+            175,
+            191
+          ]
+        },
+        "@MetaMask/transactions": {
+          "migrationPercentage": [
+            0,
+            0,
+            0
+          ],
+          "mmdsInstances": [
+            0,
+            0,
+            0
+          ],
+          "deprecatedInstances": [
+            4,
+            4,
+            4
+          ],
+          "totalInstances": [
+            4,
+            4,
+            4
+          ]
+        },
+        "@MetaMask/wallet-integrations": {
+          "migrationPercentage": [
+            0,
+            0,
+            0
+          ],
+          "mmdsInstances": [
+            0,
+            0,
+            0
+          ],
+          "deprecatedInstances": [
+            33,
+            34,
+            34
+          ],
+          "totalInstances": [
+            33,
+            34,
+            34
+          ]
+        },
+        "@MetaMask/web3auth": {
+          "migrationPercentage": [
+            0,
+            0,
+            17.68
+          ],
+          "mmdsInstances": [
+            0,
+            0,
+            32
+          ],
+          "deprecatedInstances": [
+            11,
+            11,
+            149
+          ],
+          "totalInstances": [
+            11,
+            11,
+            181
+          ]
+        },
+        "@unknown": {
+          "migrationPercentage": [
+            33.31,
+            32.97,
+            38.49
+          ],
+          "mmdsInstances": [
+            460,
+            456,
+            483
+          ],
+          "deprecatedInstances": [
+            921,
+            927,
+            772
+          ],
+          "totalInstances": [
+            1381,
+            1383,
+            1255
+          ]
+        }
+      }
+    },
     "latestChange": {
       "migrationPercentageChange": "1.79",
       "mmdsInstancesChange": 195,
@@ -2257,6 +2662,257 @@
         "ButtonFilter"
       ]
     ],
+    "codeOwnerTimeline": {
+      "dates": [
+        "2026-02-27",
+        "2026-03-06",
+        "2026-03-13"
+      ],
+      "owners": {
+        "@MetaMask/accounts-engineers": {
+          "migrationPercentage": [
+            16.14,
+            16.14,
+            17.31
+          ],
+          "mmdsInstances": [
+            72,
+            72,
+            72
+          ],
+          "deprecatedInstances": [
+            374,
+            374,
+            344
+          ],
+          "totalInstances": [
+            446,
+            446,
+            416
+          ]
+        },
+        "@MetaMask/confirmations": {
+          "migrationPercentage": [
+            14.03,
+            15.15,
+            19.95
+          ],
+          "mmdsInstances": [
+            103,
+            115,
+            157
+          ],
+          "deprecatedInstances": [
+            631,
+            644,
+            630
+          ],
+          "totalInstances": [
+            734,
+            759,
+            787
+          ]
+        },
+        "@MetaMask/core-extension-ux": {
+          "migrationPercentage": [
+            14.52,
+            16.49,
+            16.83
+          ],
+          "mmdsInstances": [
+            141,
+            156,
+            159
+          ],
+          "deprecatedInstances": [
+            830,
+            790,
+            786
+          ],
+          "totalInstances": [
+            971,
+            946,
+            945
+          ]
+        },
+        "@MetaMask/core-platform": {
+          "migrationPercentage": [
+            0.25,
+            0.25,
+            0.74
+          ],
+          "mmdsInstances": [
+            1,
+            1,
+            3
+          ],
+          "deprecatedInstances": [
+            403,
+            403,
+            401
+          ],
+          "totalInstances": [
+            404,
+            404,
+            404
+          ]
+        },
+        "@MetaMask/metamask-assets": {
+          "migrationPercentage": [
+            0.93,
+            0.94,
+            0.45
+          ],
+          "mmdsInstances": [
+            2,
+            2,
+            1
+          ],
+          "deprecatedInstances": [
+            214,
+            211,
+            222
+          ],
+          "totalInstances": [
+            216,
+            213,
+            223
+          ]
+        },
+        "@MetaMask/metamask-earn": {
+          "migrationPercentage": [
+            100,
+            100,
+            100
+          ],
+          "mmdsInstances": [
+            3,
+            3,
+            36
+          ],
+          "deprecatedInstances": [
+            0,
+            0,
+            0
+          ],
+          "totalInstances": [
+            3,
+            3,
+            36
+          ]
+        },
+        "@MetaMask/notifications": {
+          "migrationPercentage": [
+            0,
+            30.51,
+            30.51
+          ],
+          "mmdsInstances": [
+            0,
+            18,
+            18
+          ],
+          "deprecatedInstances": [
+            57,
+            41,
+            41
+          ],
+          "totalInstances": [
+            57,
+            59,
+            59
+          ]
+        },
+        "@MetaMask/perps": {
+          "migrationPercentage": [
+            89.3,
+            85.16,
+            85.16
+          ],
+          "mmdsInstances": [
+            634,
+            568,
+            568
+          ],
+          "deprecatedInstances": [
+            76,
+            99,
+            99
+          ],
+          "totalInstances": [
+            710,
+            667,
+            667
+          ]
+        },
+        "@MetaMask/swaps-engineers": {
+          "migrationPercentage": [
+            12.35,
+            12.4,
+            13.74
+          ],
+          "mmdsInstances": [
+            31,
+            31,
+            36
+          ],
+          "deprecatedInstances": [
+            220,
+            219,
+            226
+          ],
+          "totalInstances": [
+            251,
+            250,
+            262
+          ]
+        },
+        "@MetaMask/web3auth": {
+          "migrationPercentage": [
+            42.63,
+            42.63,
+            62.32
+          ],
+          "mmdsInstances": [
+            211,
+            211,
+            306
+          ],
+          "deprecatedInstances": [
+            284,
+            284,
+            185
+          ],
+          "totalInstances": [
+            495,
+            495,
+            491
+          ]
+        },
+        "@unknown": {
+          "migrationPercentage": [
+            13.06,
+            16.82,
+            25.08
+          ],
+          "mmdsInstances": [
+            254,
+            328,
+            519
+          ],
+          "deprecatedInstances": [
+            1691,
+            1622,
+            1550
+          ],
+          "totalInstances": [
+            1945,
+            1950,
+            2069
+          ]
+        }
+      }
+    },
     "latestChange": {
       "migrationPercentageChange": "5.79",
       "mmdsInstancesChange": 370,

--- a/dashboard/src/components/CodeOwnerTrendChart.tsx
+++ b/dashboard/src/components/CodeOwnerTrendChart.tsx
@@ -1,0 +1,115 @@
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { CodeOwnerTimeline } from '../types/metrics';
+
+const TEAM_COLORS = [
+  '#3b82f6', '#ef4444', '#10b981', '#f59e0b', '#8b5cf6',
+  '#ec4899', '#06b6d4', '#f97316', '#84cc16', '#6366f1',
+  '#14b8a6', '#e11d48', '#0ea5e9', '#a855f7', '#d97706',
+  '#059669', '#7c3aed', '#dc2626', '#2563eb', '#ca8a04',
+];
+
+function isUnknownOwner(owner: string) {
+  const normalized = owner.replace(/^@/, '').toLowerCase();
+  return normalized === 'unknown' || normalized === 'metamask/unknown';
+}
+
+function formatOwnerLabel(owner: string) {
+  if (isUnknownOwner(owner)) {
+    return 'No CODEOWNERS';
+  }
+  return owner.replace('@MetaMask/', '').replace(/^@/, '');
+}
+
+interface CodeOwnerTrendChartProps {
+  codeOwnerTimeline: CodeOwnerTimeline;
+  title: string;
+  excludedOwners?: Set<string>;
+}
+
+function normalizeOwner(owner: string) {
+  return owner.replace('@MetaMask/', '').replace(/^@/, '').toLowerCase();
+}
+
+export function CodeOwnerTrendChart({ codeOwnerTimeline, title, excludedOwners }: CodeOwnerTrendChartProps) {
+  const { dates, owners } = codeOwnerTimeline;
+
+  if (dates.length === 0) {
+    return (
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">{title}</h3>
+        <p className="text-gray-500 dark:text-gray-400">No historical code owner data available yet</p>
+      </div>
+    );
+  }
+
+  const activeOwners = Object.entries(owners)
+    .filter(([owner, data]) => {
+      if (excludedOwners?.has(normalizeOwner(owner))) return false;
+      return data.totalInstances.some(v => v > 0);
+    })
+    .sort((a, b) => {
+      const aLatest = a[1].totalInstances[a[1].totalInstances.length - 1];
+      const bLatest = b[1].totalInstances[b[1].totalInstances.length - 1];
+      return bLatest - aLatest;
+    });
+
+  const chartData = dates.map((date, i) => {
+    const point: Record<string, string | number> = { date };
+    for (const [owner, data] of activeOwners) {
+      point[formatOwnerLabel(owner)] = data.migrationPercentage[i];
+    }
+    return point;
+  });
+
+  const CustomTooltip = ({ active, payload, label }: any) => {
+    if (!active || !payload?.length) return null;
+
+    const sorted = [...payload].sort((a: any, b: any) => (b.value ?? 0) - (a.value ?? 0));
+
+    return (
+      <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3 max-h-80 overflow-y-auto">
+        <p className="font-semibold text-gray-900 dark:text-white mb-2">{label}</p>
+        {sorted.map((entry: any) => (
+          <p key={entry.dataKey} className="text-sm" style={{ color: entry.color }}>
+            {entry.dataKey}: {entry.value?.toFixed(1)}%
+          </p>
+        ))}
+      </div>
+    );
+  };
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+      <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">{title}</h3>
+      <ResponsiveContainer width="100%" height={450}>
+        <LineChart data={chartData}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis
+            dataKey="date"
+            tick={{ fontSize: 12 }}
+            angle={-45}
+            textAnchor="end"
+            height={80}
+          />
+          <YAxis
+            domain={[0, 100]}
+            label={{ value: 'Migration %', angle: -90, position: 'insideLeft' }}
+          />
+          <Tooltip content={<CustomTooltip />} />
+          <Legend wrapperStyle={{ fontSize: 12 }} />
+          {activeOwners.map(([owner], i) => (
+            <Line
+              key={owner}
+              type="monotone"
+              dataKey={formatOwnerLabel(owner)}
+              stroke={TEAM_COLORS[i % TEAM_COLORS.length]}
+              strokeWidth={2}
+              dot={{ r: 3 }}
+              connectNulls
+            />
+          ))}
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/dashboard/src/pages/Overview.tsx
+++ b/dashboard/src/pages/Overview.tsx
@@ -4,6 +4,7 @@ import { Loading } from '../components/Loading';
 import { ErrorMessage } from '../components/ErrorMessage';
 import { MetricsCard } from '../components/MetricsCard';
 import { CodeOwnerAdoptionChart } from '../components/CodeOwnerAdoptionChart';
+import { CodeOwnerTrendChart } from '../components/CodeOwnerTrendChart';
 import { ComponentPropsAuditSection } from '../components/ComponentPropsAuditSection';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
 
@@ -336,6 +337,16 @@ export function Overview() {
               </p>
             </div>
           )}
+
+          {data.mobile.codeOwnerTimeline && data.mobile.codeOwnerTimeline.dates.length > 0 && (
+            <div className="mt-6">
+              <CodeOwnerTrendChart
+                codeOwnerTimeline={data.mobile.codeOwnerTimeline}
+                title="Mobile - Code Owner Migration Trend"
+                excludedOwners={MOBILE_EXCLUDED_OWNERS}
+              />
+            </div>
+          )}
         </section>
 
         {/* Extension Metrics */}
@@ -508,6 +519,16 @@ export function Overview() {
                 that were current at the time and were later deprecated. Those areas are then
                 updated during planned replacement phases as MMDS alternatives roll out.
               </p>
+            </div>
+          )}
+
+          {data.extension.codeOwnerTimeline && data.extension.codeOwnerTimeline.dates.length > 0 && (
+            <div className="mt-6">
+              <CodeOwnerTrendChart
+                codeOwnerTimeline={data.extension.codeOwnerTimeline}
+                title="Extension - Code Owner Migration Trend"
+                excludedOwners={EXTENSION_EXCLUDED_OWNERS}
+              />
             </div>
           )}
         </section>

--- a/dashboard/src/types/metrics.ts
+++ b/dashboard/src/types/metrics.ts
@@ -35,6 +35,18 @@ export interface MetricsData {
   components: ComponentMetrics[];
 }
 
+export interface CodeOwnerTimelineEntry {
+  migrationPercentage: number[];
+  mmdsInstances: number[];
+  deprecatedInstances: number[];
+  totalInstances: number[];
+}
+
+export interface CodeOwnerTimeline {
+  dates: string[];
+  owners: Record<string, CodeOwnerTimelineEntry>;
+}
+
 export interface ProjectTimeline {
   dates: string[];
   migrationPercentage: number[];
@@ -48,6 +60,7 @@ export interface ProjectTimeline {
   mmdsComponentsAvailable: number[];
   mmdsComponentsList: string[][];
   newComponents: string[][];
+  codeOwnerTimeline?: CodeOwnerTimeline;
   latestChange?: {
     migrationPercentageChange: string;
     mmdsInstancesChange: number;

--- a/metrics/timeline.json
+++ b/metrics/timeline.json
@@ -1178,6 +1178,411 @@
         "Spinner"
       ]
     ],
+    "codeOwnerTimeline": {
+      "dates": [
+        "2026-02-27",
+        "2026-03-06",
+        "2026-03-13"
+      ],
+      "owners": {
+        "@MetaMask/accounts-engineers": {
+          "migrationPercentage": [
+            19.29,
+            20.54,
+            20.54
+          ],
+          "mmdsInstances": [
+            38,
+            38,
+            38
+          ],
+          "deprecatedInstances": [
+            159,
+            147,
+            147
+          ],
+          "totalInstances": [
+            197,
+            185,
+            185
+          ]
+        },
+        "@MetaMask/card": {
+          "migrationPercentage": [
+            63.64,
+            64.94,
+            68.36
+          ],
+          "mmdsInstances": [
+            266,
+            276,
+            296
+          ],
+          "deprecatedInstances": [
+            152,
+            149,
+            137
+          ],
+          "totalInstances": [
+            418,
+            425,
+            433
+          ]
+        },
+        "@MetaMask/confirmations": {
+          "migrationPercentage": [
+            18.44,
+            17.35,
+            17.41
+          ],
+          "mmdsInstances": [
+            71,
+            72,
+            74
+          ],
+          "deprecatedInstances": [
+            314,
+            343,
+            351
+          ],
+          "totalInstances": [
+            385,
+            415,
+            425
+          ]
+        },
+        "@MetaMask/core-platform": {
+          "migrationPercentage": [
+            0.99,
+            0.99,
+            0.99
+          ],
+          "mmdsInstances": [
+            1,
+            1,
+            1
+          ],
+          "deprecatedInstances": [
+            100,
+            100,
+            100
+          ],
+          "totalInstances": [
+            101,
+            101,
+            101
+          ]
+        },
+        "@MetaMask/metamask-assets": {
+          "migrationPercentage": [
+            38.58,
+            38.58,
+            40.37
+          ],
+          "mmdsInstances": [
+            103,
+            103,
+            109
+          ],
+          "deprecatedInstances": [
+            164,
+            164,
+            161
+          ],
+          "totalInstances": [
+            267,
+            267,
+            270
+          ]
+        },
+        "@MetaMask/metamask-earn": {
+          "migrationPercentage": [
+            3.37,
+            3.69,
+            6.23
+          ],
+          "mmdsInstances": [
+            10,
+            11,
+            19
+          ],
+          "deprecatedInstances": [
+            287,
+            287,
+            286
+          ],
+          "totalInstances": [
+            297,
+            298,
+            305
+          ]
+        },
+        "@MetaMask/mobile-core-ux": {
+          "migrationPercentage": [
+            10.29,
+            12.41,
+            12.41
+          ],
+          "mmdsInstances": [
+            35,
+            36,
+            36
+          ],
+          "deprecatedInstances": [
+            305,
+            254,
+            254
+          ],
+          "totalInstances": [
+            340,
+            290,
+            290
+          ]
+        },
+        "@MetaMask/mobile-platform": {
+          "migrationPercentage": [
+            75,
+            75,
+            75
+          ],
+          "mmdsInstances": [
+            3,
+            3,
+            3
+          ],
+          "deprecatedInstances": [
+            1,
+            1,
+            1
+          ],
+          "totalInstances": [
+            4,
+            4,
+            4
+          ]
+        },
+        "@MetaMask/notifications": {
+          "migrationPercentage": [
+            5.06,
+            5.13,
+            5.13
+          ],
+          "mmdsInstances": [
+            4,
+            4,
+            4
+          ],
+          "deprecatedInstances": [
+            75,
+            74,
+            74
+          ],
+          "totalInstances": [
+            79,
+            78,
+            78
+          ]
+        },
+        "@MetaMask/perps": {
+          "migrationPercentage": [
+            12.9,
+            12.93,
+            13.43
+          ],
+          "mmdsInstances": [
+            104,
+            105,
+            110
+          ],
+          "deprecatedInstances": [
+            702,
+            707,
+            709
+          ],
+          "totalInstances": [
+            806,
+            812,
+            819
+          ]
+        },
+        "@MetaMask/predict": {
+          "migrationPercentage": [
+            73.3,
+            73.3,
+            75.54
+          ],
+          "mmdsInstances": [
+            409,
+            409,
+            454
+          ],
+          "deprecatedInstances": [
+            149,
+            149,
+            147
+          ],
+          "totalInstances": [
+            558,
+            558,
+            601
+          ]
+        },
+        "@MetaMask/ramp": {
+          "migrationPercentage": [
+            9.41,
+            9.87,
+            10.57
+          ],
+          "mmdsInstances": [
+            72,
+            78,
+            84
+          ],
+          "deprecatedInstances": [
+            693,
+            712,
+            711
+          ],
+          "totalInstances": [
+            765,
+            790,
+            795
+          ]
+        },
+        "@MetaMask/rewards": {
+          "migrationPercentage": [
+            88.95,
+            88.05,
+            88.14
+          ],
+          "mmdsInstances": [
+            451,
+            457,
+            483
+          ],
+          "deprecatedInstances": [
+            56,
+            62,
+            65
+          ],
+          "totalInstances": [
+            507,
+            519,
+            548
+          ]
+        },
+        "@MetaMask/swaps-engineers": {
+          "migrationPercentage": [
+            18.67,
+            33.71,
+            40.31
+          ],
+          "mmdsInstances": [
+            28,
+            59,
+            77
+          ],
+          "deprecatedInstances": [
+            122,
+            116,
+            114
+          ],
+          "totalInstances": [
+            150,
+            175,
+            191
+          ]
+        },
+        "@MetaMask/transactions": {
+          "migrationPercentage": [
+            0,
+            0,
+            0
+          ],
+          "mmdsInstances": [
+            0,
+            0,
+            0
+          ],
+          "deprecatedInstances": [
+            4,
+            4,
+            4
+          ],
+          "totalInstances": [
+            4,
+            4,
+            4
+          ]
+        },
+        "@MetaMask/wallet-integrations": {
+          "migrationPercentage": [
+            0,
+            0,
+            0
+          ],
+          "mmdsInstances": [
+            0,
+            0,
+            0
+          ],
+          "deprecatedInstances": [
+            33,
+            34,
+            34
+          ],
+          "totalInstances": [
+            33,
+            34,
+            34
+          ]
+        },
+        "@MetaMask/web3auth": {
+          "migrationPercentage": [
+            0,
+            0,
+            17.68
+          ],
+          "mmdsInstances": [
+            0,
+            0,
+            32
+          ],
+          "deprecatedInstances": [
+            11,
+            11,
+            149
+          ],
+          "totalInstances": [
+            11,
+            11,
+            181
+          ]
+        },
+        "@unknown": {
+          "migrationPercentage": [
+            33.31,
+            32.97,
+            38.49
+          ],
+          "mmdsInstances": [
+            460,
+            456,
+            483
+          ],
+          "deprecatedInstances": [
+            921,
+            927,
+            772
+          ],
+          "totalInstances": [
+            1381,
+            1383,
+            1255
+          ]
+        }
+      }
+    },
     "latestChange": {
       "migrationPercentageChange": "1.79",
       "mmdsInstancesChange": 195,
@@ -2257,6 +2662,257 @@
         "ButtonFilter"
       ]
     ],
+    "codeOwnerTimeline": {
+      "dates": [
+        "2026-02-27",
+        "2026-03-06",
+        "2026-03-13"
+      ],
+      "owners": {
+        "@MetaMask/accounts-engineers": {
+          "migrationPercentage": [
+            16.14,
+            16.14,
+            17.31
+          ],
+          "mmdsInstances": [
+            72,
+            72,
+            72
+          ],
+          "deprecatedInstances": [
+            374,
+            374,
+            344
+          ],
+          "totalInstances": [
+            446,
+            446,
+            416
+          ]
+        },
+        "@MetaMask/confirmations": {
+          "migrationPercentage": [
+            14.03,
+            15.15,
+            19.95
+          ],
+          "mmdsInstances": [
+            103,
+            115,
+            157
+          ],
+          "deprecatedInstances": [
+            631,
+            644,
+            630
+          ],
+          "totalInstances": [
+            734,
+            759,
+            787
+          ]
+        },
+        "@MetaMask/core-extension-ux": {
+          "migrationPercentage": [
+            14.52,
+            16.49,
+            16.83
+          ],
+          "mmdsInstances": [
+            141,
+            156,
+            159
+          ],
+          "deprecatedInstances": [
+            830,
+            790,
+            786
+          ],
+          "totalInstances": [
+            971,
+            946,
+            945
+          ]
+        },
+        "@MetaMask/core-platform": {
+          "migrationPercentage": [
+            0.25,
+            0.25,
+            0.74
+          ],
+          "mmdsInstances": [
+            1,
+            1,
+            3
+          ],
+          "deprecatedInstances": [
+            403,
+            403,
+            401
+          ],
+          "totalInstances": [
+            404,
+            404,
+            404
+          ]
+        },
+        "@MetaMask/metamask-assets": {
+          "migrationPercentage": [
+            0.93,
+            0.94,
+            0.45
+          ],
+          "mmdsInstances": [
+            2,
+            2,
+            1
+          ],
+          "deprecatedInstances": [
+            214,
+            211,
+            222
+          ],
+          "totalInstances": [
+            216,
+            213,
+            223
+          ]
+        },
+        "@MetaMask/metamask-earn": {
+          "migrationPercentage": [
+            100,
+            100,
+            100
+          ],
+          "mmdsInstances": [
+            3,
+            3,
+            36
+          ],
+          "deprecatedInstances": [
+            0,
+            0,
+            0
+          ],
+          "totalInstances": [
+            3,
+            3,
+            36
+          ]
+        },
+        "@MetaMask/notifications": {
+          "migrationPercentage": [
+            0,
+            30.51,
+            30.51
+          ],
+          "mmdsInstances": [
+            0,
+            18,
+            18
+          ],
+          "deprecatedInstances": [
+            57,
+            41,
+            41
+          ],
+          "totalInstances": [
+            57,
+            59,
+            59
+          ]
+        },
+        "@MetaMask/perps": {
+          "migrationPercentage": [
+            89.3,
+            85.16,
+            85.16
+          ],
+          "mmdsInstances": [
+            634,
+            568,
+            568
+          ],
+          "deprecatedInstances": [
+            76,
+            99,
+            99
+          ],
+          "totalInstances": [
+            710,
+            667,
+            667
+          ]
+        },
+        "@MetaMask/swaps-engineers": {
+          "migrationPercentage": [
+            12.35,
+            12.4,
+            13.74
+          ],
+          "mmdsInstances": [
+            31,
+            31,
+            36
+          ],
+          "deprecatedInstances": [
+            220,
+            219,
+            226
+          ],
+          "totalInstances": [
+            251,
+            250,
+            262
+          ]
+        },
+        "@MetaMask/web3auth": {
+          "migrationPercentage": [
+            42.63,
+            42.63,
+            62.32
+          ],
+          "mmdsInstances": [
+            211,
+            211,
+            306
+          ],
+          "deprecatedInstances": [
+            284,
+            284,
+            185
+          ],
+          "totalInstances": [
+            495,
+            495,
+            491
+          ]
+        },
+        "@unknown": {
+          "migrationPercentage": [
+            13.06,
+            16.82,
+            25.08
+          ],
+          "mmdsInstances": [
+            254,
+            328,
+            519
+          ],
+          "deprecatedInstances": [
+            1691,
+            1622,
+            1550
+          ],
+          "totalInstances": [
+            1945,
+            1950,
+            2069
+          ]
+        }
+      }
+    },
     "latestChange": {
       "migrationPercentageChange": "5.79",
       "mmdsInstancesChange": 370,

--- a/scripts/update-timeline.js
+++ b/scripts/update-timeline.js
@@ -69,6 +69,8 @@ async function loadAllDataFiles() {
  * Build timeline data for a project
  */
 function buildProjectTimeline(projectData) {
+  const emptyCodeOwnerTimeline = { dates: [], owners: {} };
+
   if (projectData.length === 0) {
     return {
       dates: [],
@@ -82,7 +84,8 @@ function buildProjectTimeline(projectData) {
       totalComponents: [],
       mmdsComponentsAvailable: [],
       mmdsComponentsList: [],
-      newComponents: []
+      newComponents: [],
+      codeOwnerTimeline: emptyCodeOwnerTimeline
     };
   }
 
@@ -119,7 +122,77 @@ function buildProjectTimeline(projectData) {
     timeline.newComponents.push(data.newComponents || []);
   }
 
+  timeline.codeOwnerTimeline = buildCodeOwnerTimeline(projectData);
+
   return timeline;
+}
+
+/**
+ * Build code owner timeline data from project entries.
+ *
+ * Uses its own dates array so the timeline only includes weeks where
+ * codeOwnerStats was captured (the feature was added later than the
+ * top-level metrics).
+ */
+function buildCodeOwnerTimeline(projectData) {
+  const codeOwnerTimeline = { dates: [], owners: {} };
+  const allOwners = new Set();
+  const entriesWithStats = [];
+
+  for (const entry of projectData) {
+    const stats = entry.data.summary?.codeOwnerStats;
+    if (stats && Object.keys(stats).length > 0) {
+      entriesWithStats.push(entry);
+      for (const owner of Object.keys(stats)) {
+        allOwners.add(owner);
+      }
+    }
+  }
+
+  if (entriesWithStats.length === 0) {
+    return codeOwnerTimeline;
+  }
+
+  for (const owner of allOwners) {
+    codeOwnerTimeline.owners[owner] = {
+      migrationPercentage: [],
+      mmdsInstances: [],
+      deprecatedInstances: [],
+      totalInstances: []
+    };
+  }
+
+  for (const entry of entriesWithStats) {
+    const stats = entry.data.summary.codeOwnerStats;
+    codeOwnerTimeline.dates.push(entry.date);
+
+    for (const owner of allOwners) {
+      const ownerStats = stats[owner];
+      const ownerTimeline = codeOwnerTimeline.owners[owner];
+      ownerTimeline.migrationPercentage.push(
+        ownerStats ? parseFloat(ownerStats.migrationPercentage) : 0
+      );
+      ownerTimeline.mmdsInstances.push(
+        ownerStats ? ownerStats.mmdsInstances : 0
+      );
+      ownerTimeline.deprecatedInstances.push(
+        ownerStats ? ownerStats.deprecatedInstances : 0
+      );
+      ownerTimeline.totalInstances.push(
+        ownerStats ? ownerStats.totalInstances : 0
+      );
+    }
+  }
+
+  for (const owner of allOwners) {
+    const ownerTimeline = codeOwnerTimeline.owners[owner];
+    const hasActivity = ownerTimeline.totalInstances.some(v => v > 0);
+    if (!hasActivity) {
+      delete codeOwnerTimeline.owners[owner];
+    }
+  }
+
+  return codeOwnerTimeline;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Aggregates `codeOwnerStats` from weekly data files into `timeline.json` so the dashboard can show week-over-week migration progress per team
- Adds a new `CodeOwnerTrendChart` line chart component showing migration % over time for each code owner
- Wired into the Overview page for both Mobile and Extension sections (renders below the existing adoption bar charts)

<img width="762" height="455" alt="Screenshot 2026-03-16 at 8 39 13 AM" src="https://github.com/user-attachments/assets/4412028b-c431-4e54-be7a-66afacefcfec" />

## Details

`update-timeline.js` now extracts a `codeOwnerTimeline` block with its own `dates` array (separate from the main timeline since codeowner tracking only started 2026-02-27). Teams with zero activity across all dates are excluded.

Currently shows 3 weeks of data (Feb 27, Mar 6, Mar 13). Future weekly pipeline runs will keep accumulating data points automatically — no additional changes needed.

## Highlight

The charts already surface notable progress:
- **@MetaMask/web3auth** (extension): 42.63% → 62.32% (+19.69pp in one week)
- **@MetaMask/card** (mobile): 63.64% → 68.36% (+4.72pp over 3 weeks)