### PR TITLE
fix: use total MMDS instances for migration percentage calculation

### DIFF
--- a/dashboard/public/metrics/extension-component-metrics-2026-03-13-data.json
+++ b/dashboard/public/metrics/extension-component-metrics-2026-03-13-data.json
@@ -1,7 +1,7 @@
 {
   "project": "extension",
   "date": "2026-03-13",
-  "generatedAt": "2026-03-13T16:21:14.618Z",
+  "generatedAt": "2026-03-16T17:17:03.582Z",
   "mmdsComponentsAvailable": 28,
   "mmdsComponentsList": [
     "AvatarAccount",
@@ -35,15 +35,14 @@
   ],
   "newComponents": [
     "BannerAlert",
-    "BannerBase",
     "ButtonFilter"
   ],
   "summary": {
     "totalComponents": 17,
     "mmdsInstances": 1875,
     "deprecatedInstances": 3554,
-    "totalInstances": 5409,
-    "migrationPercentage": "34.29",
+    "totalInstances": 5429,
+    "migrationPercentage": "34.54",
     "fullyMigrated": 0,
     "inProgress": 13,
     "notStarted": 4,

--- a/dashboard/public/metrics/extension-component-metrics-2026-03-13-summary.json
+++ b/dashboard/public/metrics/extension-component-metrics-2026-03-13-summary.json
@@ -4,8 +4,8 @@
   "mmdsInstances": 1875,
   "deprecatedInstances": 3554,
   "mmdsUsageTotal": 1855,
-  "totalInstances": 5409,
-  "migrationPercentage": "34.29",
+  "totalInstances": 5429,
+  "migrationPercentage": "34.54",
   "componentsTracked": 17,
   "mmdsComponentsAvailable": 28,
   "mmdsComponentsList": [
@@ -40,7 +40,6 @@
   ],
   "newComponents": [
     "BannerAlert",
-    "BannerBase",
     "ButtonFilter"
   ],
   "noReplacementComponents": 22,

--- a/dashboard/public/metrics/index.json
+++ b/dashboard/public/metrics/index.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "2026-03-13T16:23:54.142Z",
+  "lastUpdated": "2026-03-16T17:18:08.529Z",
   "projects": {
     "mobile": [
       {

--- a/dashboard/public/metrics/mobile-component-metrics-2026-03-13-data.json
+++ b/dashboard/public/metrics/mobile-component-metrics-2026-03-13-data.json
@@ -1,7 +1,7 @@
 {
   "project": "mobile",
   "date": "2026-03-13",
-  "generatedAt": "2026-03-13T16:23:53.577Z",
+  "generatedAt": "2026-03-16T17:17:46.650Z",
   "mmdsComponentsAvailable": 49,
   "mmdsComponentsList": [
     "ActionListItem",
@@ -55,27 +55,20 @@
     "Toast"
   ],
   "newComponents": [
-    "ActionListItem",
     "BannerAlert",
-    "BannerBase",
     "BottomSheet",
-    "BottomSheetHeader",
     "ButtonFilter",
-    "ButtonHero",
-    "ButtonSemantic",
     "ImageOrSvg",
-    "ListItem",
     "MainActionButton",
     "SensitiveText",
-    "Spinner",
-    "TabEmptyState"
+    "Spinner"
   ],
   "summary": {
     "totalComponents": 36,
     "mmdsInstances": 2303,
     "deprecatedInstances": 3443,
-    "totalInstances": 4476,
-    "migrationPercentage": "23.08",
+    "totalInstances": 5746,
+    "migrationPercentage": "40.08",
     "fullyMigrated": 0,
     "inProgress": 11,
     "notStarted": 25,

--- a/dashboard/public/metrics/mobile-component-metrics-2026-03-13-summary.json
+++ b/dashboard/public/metrics/mobile-component-metrics-2026-03-13-summary.json
@@ -4,8 +4,8 @@
   "mmdsInstances": 2303,
   "deprecatedInstances": 3443,
   "mmdsUsageTotal": 1033,
-  "totalInstances": 4476,
-  "migrationPercentage": "23.08",
+  "totalInstances": 5746,
+  "migrationPercentage": "40.08",
   "componentsTracked": 36,
   "mmdsComponentsAvailable": 49,
   "mmdsComponentsList": [
@@ -60,20 +60,13 @@
     "Toast"
   ],
   "newComponents": [
-    "ActionListItem",
     "BannerAlert",
-    "BannerBase",
     "BottomSheet",
-    "BottomSheetHeader",
     "ButtonFilter",
-    "ButtonHero",
-    "ButtonSemantic",
     "ImageOrSvg",
-    "ListItem",
     "MainActionButton",
     "SensitiveText",
-    "Spinner",
-    "TabEmptyState"
+    "Spinner"
   ],
   "noReplacementComponents": 42,
   "totalNoReplacementInstances": 567,

--- a/dashboard/public/metrics/timeline.json
+++ b/dashboard/public/metrics/timeline.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-03-13T16:23:54.137Z",
+  "generatedAt": "2026-03-16T17:18:08.527Z",
   "mobile": {
     "dates": [
       "2025-08-29",
@@ -59,7 +59,7 @@
       20.29,
       21.31,
       21.32,
-      23.08
+      40.08
     ],
     "mmdsInstances": [
       169,
@@ -149,7 +149,7 @@
       4027,
       4162,
       4319,
-      4476
+      5746
     ],
     "componentsFullyMigrated": [
       0,
@@ -1169,24 +1169,17 @@
         "TabEmptyState"
       ],
       [
-        "ActionListItem",
         "BannerAlert",
-        "BannerBase",
         "BottomSheet",
-        "BottomSheetHeader",
         "ButtonFilter",
-        "ButtonHero",
-        "ButtonSemantic",
         "ImageOrSvg",
-        "ListItem",
         "MainActionButton",
         "SensitiveText",
-        "Spinner",
-        "TabEmptyState"
+        "Spinner"
       ]
     ],
     "latestChange": {
-      "migrationPercentageChange": "1.76",
+      "migrationPercentageChange": "18.76",
       "mmdsInstancesChange": 195,
       "deprecatedInstancesChange": 45,
       "componentsFullyMigratedChange": 0,
@@ -1253,7 +1246,7 @@
       26.91,
       27.2,
       28.5,
-      34.29
+      34.54
     ],
     "mmdsInstances": [
       101,
@@ -1343,7 +1336,7 @@
       5270,
       5272,
       5217,
-      5409
+      5429
     ],
     "componentsFullyMigrated": [
       0,
@@ -2261,12 +2254,11 @@
       ],
       [
         "BannerAlert",
-        "BannerBase",
         "ButtonFilter"
       ]
     ],
     "latestChange": {
-      "migrationPercentageChange": "5.79",
+      "migrationPercentageChange": "6.04",
       "mmdsInstancesChange": 370,
       "deprecatedInstancesChange": -176,
       "componentsFullyMigratedChange": 0,

--- a/index.js
+++ b/index.js
@@ -718,9 +718,9 @@ const main = async () => {
 
     // Write summary JSON for Slack report
     const summaryFile = outputFile.replace(".xlsx", "-summary.json");
-    const summaryTotalAll = totalDeprecated + totalMMDS;
+    const summaryTotalAll = totalDeprecated + totalMMDSUsage;
     const summaryTotalPercentage =
-      summaryTotalAll > 0 ? (totalMMDS / summaryTotalAll) * 100 : 0;
+      summaryTotalAll > 0 ? (totalMMDSUsage / summaryTotalAll) * 100 : 0;
 
     const mmdsComponentsAvailable = countAvailableMMDSComponents(
       projectConfig.currentComponents,

--- a/metrics/extension-component-metrics-2026-03-13-data.json
+++ b/metrics/extension-component-metrics-2026-03-13-data.json
@@ -1,7 +1,7 @@
 {
   "project": "extension",
   "date": "2026-03-13",
-  "generatedAt": "2026-03-13T16:21:14.618Z",
+  "generatedAt": "2026-03-16T17:17:03.582Z",
   "mmdsComponentsAvailable": 28,
   "mmdsComponentsList": [
     "AvatarAccount",
@@ -35,15 +35,14 @@
   ],
   "newComponents": [
     "BannerAlert",
-    "BannerBase",
     "ButtonFilter"
   ],
   "summary": {
     "totalComponents": 17,
     "mmdsInstances": 1875,
     "deprecatedInstances": 3554,
-    "totalInstances": 5409,
-    "migrationPercentage": "34.29",
+    "totalInstances": 5429,
+    "migrationPercentage": "34.54",
     "fullyMigrated": 0,
     "inProgress": 13,
     "notStarted": 4,

--- a/metrics/extension-component-metrics-2026-03-13-summary.json
+++ b/metrics/extension-component-metrics-2026-03-13-summary.json
@@ -4,8 +4,8 @@
   "mmdsInstances": 1875,
   "deprecatedInstances": 3554,
   "mmdsUsageTotal": 1855,
-  "totalInstances": 5409,
-  "migrationPercentage": "34.29",
+  "totalInstances": 5429,
+  "migrationPercentage": "34.54",
   "componentsTracked": 17,
   "mmdsComponentsAvailable": 28,
   "mmdsComponentsList": [
@@ -40,7 +40,6 @@
   ],
   "newComponents": [
     "BannerAlert",
-    "BannerBase",
     "ButtonFilter"
   ],
   "noReplacementComponents": 22,

--- a/metrics/index.json
+++ b/metrics/index.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "2026-03-13T16:23:54.142Z",
+  "lastUpdated": "2026-03-16T17:18:08.529Z",
   "projects": {
     "mobile": [
       {

--- a/metrics/mobile-component-metrics-2026-03-13-data.json
+++ b/metrics/mobile-component-metrics-2026-03-13-data.json
@@ -1,7 +1,7 @@
 {
   "project": "mobile",
   "date": "2026-03-13",
-  "generatedAt": "2026-03-13T16:23:53.577Z",
+  "generatedAt": "2026-03-16T17:17:46.650Z",
   "mmdsComponentsAvailable": 49,
   "mmdsComponentsList": [
     "ActionListItem",
@@ -55,27 +55,20 @@
     "Toast"
   ],
   "newComponents": [
-    "ActionListItem",
     "BannerAlert",
-    "BannerBase",
     "BottomSheet",
-    "BottomSheetHeader",
     "ButtonFilter",
-    "ButtonHero",
-    "ButtonSemantic",
     "ImageOrSvg",
-    "ListItem",
     "MainActionButton",
     "SensitiveText",
-    "Spinner",
-    "TabEmptyState"
+    "Spinner"
   ],
   "summary": {
     "totalComponents": 36,
     "mmdsInstances": 2303,
     "deprecatedInstances": 3443,
-    "totalInstances": 4476,
-    "migrationPercentage": "23.08",
+    "totalInstances": 5746,
+    "migrationPercentage": "40.08",
     "fullyMigrated": 0,
     "inProgress": 11,
     "notStarted": 25,

--- a/metrics/mobile-component-metrics-2026-03-13-summary.json
+++ b/metrics/mobile-component-metrics-2026-03-13-summary.json
@@ -4,8 +4,8 @@
   "mmdsInstances": 2303,
   "deprecatedInstances": 3443,
   "mmdsUsageTotal": 1033,
-  "totalInstances": 4476,
-  "migrationPercentage": "23.08",
+  "totalInstances": 5746,
+  "migrationPercentage": "40.08",
   "componentsTracked": 36,
   "mmdsComponentsAvailable": 49,
   "mmdsComponentsList": [
@@ -60,20 +60,13 @@
     "Toast"
   ],
   "newComponents": [
-    "ActionListItem",
     "BannerAlert",
-    "BannerBase",
     "BottomSheet",
-    "BottomSheetHeader",
     "ButtonFilter",
-    "ButtonHero",
-    "ButtonSemantic",
     "ImageOrSvg",
-    "ListItem",
     "MainActionButton",
     "SensitiveText",
-    "Spinner",
-    "TabEmptyState"
+    "Spinner"
   ],
   "noReplacementComponents": 42,
   "totalNoReplacementInstances": 567,

--- a/metrics/timeline.json
+++ b/metrics/timeline.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-03-13T16:23:54.137Z",
+  "generatedAt": "2026-03-16T17:18:08.527Z",
   "mobile": {
     "dates": [
       "2025-08-29",
@@ -59,7 +59,7 @@
       20.29,
       21.31,
       21.32,
-      23.08
+      40.08
     ],
     "mmdsInstances": [
       169,
@@ -149,7 +149,7 @@
       4027,
       4162,
       4319,
-      4476
+      5746
     ],
     "componentsFullyMigrated": [
       0,
@@ -1169,24 +1169,17 @@
         "TabEmptyState"
       ],
       [
-        "ActionListItem",
         "BannerAlert",
-        "BannerBase",
         "BottomSheet",
-        "BottomSheetHeader",
         "ButtonFilter",
-        "ButtonHero",
-        "ButtonSemantic",
         "ImageOrSvg",
-        "ListItem",
         "MainActionButton",
         "SensitiveText",
-        "Spinner",
-        "TabEmptyState"
+        "Spinner"
       ]
     ],
     "latestChange": {
-      "migrationPercentageChange": "1.76",
+      "migrationPercentageChange": "18.76",
       "mmdsInstancesChange": 195,
       "deprecatedInstancesChange": 45,
       "componentsFullyMigratedChange": 0,
@@ -1253,7 +1246,7 @@
       26.91,
       27.2,
       28.5,
-      34.29
+      34.54
     ],
     "mmdsInstances": [
       101,
@@ -1343,7 +1336,7 @@
       5270,
       5272,
       5217,
-      5409
+      5429
     ],
     "componentsFullyMigrated": [
       0,
@@ -2261,12 +2254,11 @@
       ],
       [
         "BannerAlert",
-        "BannerBase",
         "ButtonFilter"
       ]
     ],
     "latestChange": {
-      "migrationPercentageChange": "5.79",
+      "migrationPercentageChange": "6.04",
       "mmdsInstancesChange": 370,
       "deprecatedInstancesChange": -176,
       "componentsFullyMigratedChange": 0,


### PR DESCRIPTION
## Summary

The dashboard's migration percentage was calculated from a different MMDS count than what was displayed, making the numbers appear inconsistent.

## Problem

`index.js` tracked two separate MMDS totals:
- `totalMMDSUsage` (2,303 mobile) — ALL MMDS component instances across the codebase
- `totalMMDS` (1,033 mobile) — only MMDS instances that directly replace a tracked deprecated component

The summary wrote `mmdsInstances: totalMMDSUsage` but calculated `migrationPercentage` from `totalMMDS`. So the dashboard showed:

> MMDS Instances: **2,303** / Deprecated: **3,443** / Migration: **23.08%**

When the displayed formula ("MMDS / (MMDS + Deprecated)") would produce **40.08%**.

## Fix

One-line change: use `totalMMDSUsage` instead of `totalMMDS` for the migration percentage calculation. The displayed numbers are now self-consistent:

| Project | Before | After |
|---------|--------|-------|
| Mobile | 23.08% | 40.08% |
| Extension | 28.50% | 34.54% |

Regenerated latest metrics, timeline, and dashboard data to reflect the corrected calculation.