### PR TITLE
Ignore Ramp/Deposit and Ramp/Aggregator in mobile code owner metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Notes:
 The tool uses `config.json` project entries with:
 - `filePattern`, `ignoreFolders`, `outputFile`
 - `currentPackages`, `currentComponents`
+- `codeOwnerMetricIgnoreGlobs` (optional): array of globs to exclude from code owner adoption metrics only (does not affect overall component counts). Useful for ignoring legacy or soon-to-be-deprecated areas from team adoption charts.
 - `deprecatedComponents` mappings:
   - `paths`: import paths to match
   - `replacement`: MMDS target or `null`

--- a/config.json
+++ b/config.json
@@ -531,6 +531,10 @@
       ],
       "filePattern": "repos/metamask-mobile/app/components/**/*.{js,jsx,ts,tsx}",
       "outputFile": "metrics/mobile-component-metrics.xlsx",
+      "codeOwnerMetricIgnoreGlobs": [
+        "app/components/**/Ramp/Deposit/**",
+        "app/components/**/Ramp/Aggregator/**"
+      ],
       "currentPackages": [
         "@metamask/design-system-react-native"
       ],

--- a/index.js
+++ b/index.js
@@ -10,9 +10,11 @@ const { program } = require("commander");
 const chalk = require("chalk");
 const ExcelJS = require("exceljs");
 const CodeOwnersParser = require("./scripts/codeowners-parser");
+const { minimatch } = require("minimatch");
 
 let config;
 let codeOwnersParser = null;
+let codeOwnerMetricIgnoreGlobs = [];
 
 // Function to load and parse the configuration file
 const loadConfig = async (configPath) => {
@@ -175,6 +177,12 @@ const trackComponent = (componentName, source, specificPath, filePath) => {
       if (relativePath && !relativePath.startsWith("..")) {
         lookupPath = relativePath;
       }
+    }
+
+    // If this file is part of a path we want to exclude from code owner metrics,
+    // skip tracking it for the code owner stats only.
+    if (codeOwnerMetricIgnoreGlobs.some((pattern) => minimatch(lookupPath, pattern, { dot: true }))) {
+      return;
     }
 
     const owner = codeOwnersParser.getPrimaryOwner(lookupPath);
@@ -379,6 +387,7 @@ const main = async () => {
     deprecatedComponents = {},
     currentComponents = [],
     currentPackages = [],
+    codeOwnerMetricIgnoreGlobs: projectCodeOwnerIgnore = [],
   } = projectConfig;
 
   // Add date to the output filename (from env var or today)
@@ -402,6 +411,11 @@ const main = async () => {
   if (!repoRootPath) {
     repoRootPath = process.cwd();
   }
+
+  // Configure per-project exclusions for code owner metrics (does not affect other metrics).
+  codeOwnerMetricIgnoreGlobs = (projectCodeOwnerIgnore || []).map((pattern) =>
+    pattern.replace(/\\/g, "/"),
+  );
 
   // Initialize CodeOwners parser
   const codeownersCandidates = [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Summary
- Add support for per-project exclusion globs that are applied only to code owner adoption metrics (no change to component totals).
- Configure the mobile project to ignore `app/components/**/Ramp/Deposit/**` and `app/components/**/Ramp/Aggregator/**` when tallying code owner stats.
- Document the new `codeOwnerMetricIgnoreGlobs` option in `README.md`.

Why
Ramps are mid‑migration and the legacy Deposit/Aggregator flows inflate the CODEOWNERS‑based team adoption view. The request is to exclude those subfolders from code owner metrics while keeping them in the overall component usage counts.

Implementation
- index.js: introduce `codeOwnerMetricIgnoreGlobs` handling and skip code owner tracking for files whose repo‑relative path matches any configured glob (using minimatch). Other metrics remain unchanged.
- config.json (mobile): add globs for `Ramp/Deposit` and `Ramp/Aggregator` under `app/components/`.
- README: document the new config option.

Validation
1) Run locally (after submodules):
   - `yarn setup-repos`
   - `yarn start:mobile`
2) Inspect `metrics/mobile-component-metrics-YYYY-MM-DD-summary.json` and `*-data.json`:
   - `summary.codeOwnerStats['@MetaMask/Ramps']` should no longer count files under `app/components/**/Ramp/Deposit/**` or `.../Ramp/Aggregator/**`.
   - Overall `deprecatedInstances` totals are unchanged relative to legacy components still present.
3) Optional: `yarn update-timeline && yarn validate-metrics`.

Notes
- Exclusions are repo‑relative; they only filter the team adoption slice and do not alter the deprecated/current component breakdowns.
- If additional legacy paths need to be excluded, append more globs to `codeOwnerMetricIgnoreGlobs` for the project.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://consensys.slack.com/archives/C04G8UGLL4R/p1773339316579889?thread_ts=1773339316.579889&cid=C04G8UGLL4R)

<div><a href="https://cursor.com/agents/bc-8efc2f8c-f37a-5c9d-9549-8efeaacc5c27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8efc2f8c-f37a-5c9d-9549-8efeaacc5c27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

