### PR TITLE
ci: weekly metrics via PR and MetaMask org conventions

### DIFF
--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -8,11 +8,6 @@ on:
       - 'dashboard/**'
       - 'metrics/*.json'
       - '.github/workflows/deploy-dashboard.yml'
-  workflow_run:
-    workflows:
-      - Weekly Design System Metrics
-    types:
-      - completed
   workflow_dispatch: # Allow manual trigger
 
 permissions:
@@ -27,7 +22,6 @@ concurrency:
 
 jobs:
   build:
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/weekly-metrics.yml
+++ b/.github/workflows/weekly-metrics.yml
@@ -2,12 +2,14 @@ name: Weekly Design System Metrics
 
 on:
   schedule:
-    # Run every Friday at 4:00 PM UTC (8:00 AM PST / 11:00 AM EST)
-    - cron: '0 16 * * 5'
+    # Friday 8:00 AM America/Los_Angeles (handles PST/PDT; was 16:00 UTC which is 9am Pacific during DST)
+    - cron: '0 8 * * 5'
+      timezone: America/Los_Angeles
   workflow_dispatch: # Allow manual trigger
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   generate-metrics:
@@ -32,8 +34,8 @@ jobs:
 
       - name: Initialize git submodules
         run: |
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "github-actions[bot]"
+          git config --global user.email 'metamaskbot@users.noreply.github.com'
+          git config --global user.name 'metamaskbot'
           git submodule update --init --recursive || true
 
       - name: Update git submodules
@@ -89,18 +91,38 @@ jobs:
           cd dashboard
           npm run build
 
-      - name: Commit and push changes
+      - name: Commit, push branch, open pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "github-actions[bot]"
+          set -e
+          git config --global user.email 'metamaskbot@users.noreply.github.com'
+          git config --global user.name 'metamaskbot'
           git add .
-          git commit -m "chore: weekly metrics update ${{ steps.date.outputs.date }}
-
-          - Updated git submodules to latest versions
-          - Regenerated component metrics for extension and mobile
-          - Updated config.json with latest component mappings
-          - Generated weekly Slack report
-          - Updated dashboard data and rebuilt
-
-          🤖 Automated weekly update" || echo "No changes to commit"
-          git push origin main
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+          BRANCH="metamaskbot/weekly-metrics-${{ steps.date.outputs.date }}-${{ github.run_id }}"
+          git checkout -b "$BRANCH"
+          git commit -m "chore: weekly metrics update ${{ steps.date.outputs.date }}" \
+            -m "- Updated git submodules to latest versions" \
+            -m "- Regenerated component metrics for extension and mobile" \
+            -m "- Updated config.json with latest component mappings" \
+            -m "- Generated weekly Slack report" \
+            -m "- Updated dashboard data and rebuilt" \
+            -m "" \
+            -m "🤖 Automated weekly update"
+          git push -u origin "$BRANCH"
+          BODY_FILE="$(mktemp)"
+          {
+            echo "Automated weekly metrics run."
+            echo ""
+            echo "- [ ] Review generated artifacts and merge to publish the dashboard (merge to **main** triggers GitHub Pages deploy)."
+            echo ""
+            echo "🤖 Workflow: https://github.com/${{ github.repository }}/blob/main/.github/workflows/weekly-metrics.yml"
+          } > "$BODY_FILE"
+          gh pr create --base main --head "$BRANCH" \
+            --title "chore: weekly metrics update ${{ steps.date.outputs.date }}" \
+            --body-file "$BODY_FILE"
+          rm -f "$BODY_FILE"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ For any change touching generation or schemas:
 - Keep JSON schemas backward-compatible unless you also update dashboard types and readers.
 - Do not hand-edit generated files in `metrics/` unless explicitly doing a repair/backfill task.
 - Prefer updating `config.json` via `yarn sync-config`; reserve manual edits for intentional overrides.
-- Weekly automation truth is in `.github/workflows/weekly-metrics.yml`.
+- Weekly automation truth is in `.github/workflows/weekly-metrics.yml` (opens a PR to `main`; merge to deploy via `deploy-dashboard.yml`).
 
 ## Documentation Policy
 

--- a/README.md
+++ b/README.md
@@ -95,10 +95,10 @@ METRICS_DATE=2026-03-04 yarn start:mobile
 
 CI workflows:
 - `.github/workflows/weekly-metrics.yml`
-  - runs Fridays (`0 16 * * 5`) and manually
+  - runs Fridays (8:00 AM `America/Los_Angeles`) and manually; opens a PR to `main` (org rules require changes via PR)
   - updates submodules/config, regenerates metrics, updates timeline/index, validates data, generates Slack output, and rebuilds dashboard assets
 - `.github/workflows/deploy-dashboard.yml`
-  - deploys dashboard to GitHub Pages when dashboard or metrics JSON changes on `main`
+  - deploys dashboard to GitHub Pages when dashboard or metrics JSON changes on `main` (merge the weekly metrics PR to publish)
 
 ---
 


### PR DESCRIPTION
## Summary
Aligns the weekly metrics automation with MetaMask org **branch rules** (no direct pushes to `main`) and common bot conventions.

## Changes
- **Weekly workflow**: Push branch `metamaskbot/weekly-metrics-<date>-<run_id>`, open PR with `gh pr create`; grant `pull-requests: write`.
- **Git identity**: Use `metamaskbot` / `metamaskbot@users.noreply.github.com` for commits (same pattern as extension/mobile bot workflows).
- **Schedule**: Friday 8:00 `America/Los_Angeles` (DST-safe).
- **Deploy workflow**: Drop `workflow_run` trigger on weekly job completion so Pages does not build stale `main` before the metrics PR is merged; deploy still runs on push to `main` when paths match.
- **Docs**: README + AGENTS note PR → merge → deploy.

## Testing
- [ ] Merge, then run **Weekly Design System Metrics** manually and confirm a PR is opened and checks pass.

## Related
Fixes failed runs with `GH013: Changes must be made through a pull request`.

Made with [Cursor](https://cursor.com)