### PR TITLE
ci: fix weekly workflow parse error (remove schedule timezone)

### DIFF
--- a/.github/workflows/weekly-metrics.yml
+++ b/.github/workflows/weekly-metrics.yml
@@ -2,9 +2,9 @@ name: Weekly Design System Metrics
 
 on:
   schedule:
-    # Friday 8:00 AM America/Los_Angeles (handles PST/PDT; was 16:00 UTC which is 9am Pacific during DST)
-    - cron: '0 8 * * 5'
-      timezone: America/Los_Angeles
+    # Friday 16:00 UTC. GitHub.com supports `timezone:` on schedules; this org's runners reject it ("not yet supported"),
+    # so we use UTC only. 16:00 UTC ≈ 8:00 AM PST / 9:00 AM PDT (America/Los_Angeles).
+    - cron: '0 16 * * 5'
   workflow_dispatch: # Allow manual trigger
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ METRICS_DATE=2026-03-04 yarn start:mobile
 
 CI workflows:
 - `.github/workflows/weekly-metrics.yml`
-  - runs Fridays (8:00 AM `America/Los_Angeles`) and manually; opens a PR to `main` (org rules require changes via PR)
+  - runs Fridays 16:00 UTC (~8am Pacific standard / ~9am Pacific daylight) and manually; opens a PR to `main` (org rules require changes via PR)
   - updates submodules/config, regenerates metrics, updates timeline/index, validates data, generates Slack output, and rebuilds dashboard assets
 - `.github/workflows/deploy-dashboard.yml`
   - deploys dashboard to GitHub Pages when dashboard or metrics JSON changes on `main` (merge the weekly metrics PR to publish)


### PR DESCRIPTION
## Problem
Manual runs fail to queue: `Invalid Argument - timezone in scheduled workflows is not yet supported` (org GitHub / GHES does not accept `timezone:` on `schedule`).

## Change
- Remove `timezone: America/Los_Angeles`; use Friday `0 16 * * 5` UTC only.
- Comment + README note: 16:00 UTC ≈ 8am PST / 9am PDT.

## Note
When the platform supports schedule timezones, we can restore IANA `timezone` for a fixed local Friday 8am.

Made with [Cursor](https://cursor.com)